### PR TITLE
Clean up veth test setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3"
 rand = "0.8"
 rtnetlink = "0.7"
 env_logger = "0.8"
+serial_test = "0.5"
 
 [dev-dependencies.tokio]
 version = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ crossbeam-channel = "0.5"
 ctrlc = "3.1"
 etherparse = "0.9"
 futures = "0.3"
-rand = "0.8.3"
+rand = "0.8"
 rtnetlink = "0.7"
 env_logger = "0.8"
 
 [dev-dependencies.tokio]
 version = "1.6"
 default-features = false
-features =  ["rt-multi-thread", "macros", "sync", "signal"]
+features =  ["rt-multi-thread", "macros", "sync", "signal", "time"]

--- a/tests/comp_queue_tests.rs
+++ b/tests/comp_queue_tests.rs
@@ -1,9 +1,7 @@
 use std::{thread, time::Duration};
-
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
-
 use setup::{SocketConfigBuilder, UmemConfigBuilder, Xsk};
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {

--- a/tests/comp_queue_tests.rs
+++ b/tests/comp_queue_tests.rs
@@ -1,3 +1,4 @@
+use serial_test::serial;
 use std::{thread, time::Duration};
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
@@ -22,6 +23,7 @@ fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
 }
 
 #[tokio::test]
+#[serial]
 async fn comp_queue_consumes_nothing_if_tx_q_unused() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let mut dev1_frames = dev1.frame_descs;
@@ -43,6 +45,7 @@ async fn comp_queue_consumes_nothing_if_tx_q_unused() {
 }
 
 #[tokio::test]
+#[serial]
 async fn num_frames_consumed_match_those_produced() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let mut dev1_frames = dev1.frame_descs;
@@ -72,6 +75,7 @@ async fn num_frames_consumed_match_those_produced() {
 }
 
 #[tokio::test]
+#[serial]
 async fn addr_of_frames_consumed_match_addr_of_those_produced() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let dev1_tx_q_frames = dev1.frame_descs;

--- a/tests/fill_queue_tests.rs
+++ b/tests/fill_queue_tests.rs
@@ -1,3 +1,4 @@
+use serial_test::serial;
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
@@ -15,6 +16,7 @@ fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
 }
 
 #[tokio::test]
+#[serial]
 async fn fill_queue_produce_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let frame_descs = dev1.frame_descs;
@@ -36,6 +38,7 @@ async fn fill_queue_produce_tx_size_frames() {
 }
 
 #[tokio::test]
+#[serial]
 async fn fill_queue_produce_gt_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let frame_descs = dev1.frame_descs;
@@ -57,6 +60,7 @@ async fn fill_queue_produce_gt_tx_size_frames() {
 }
 
 #[tokio::test]
+#[serial]
 async fn fill_queue_produce_frames_until_full() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let frame_descs = dev1.frame_descs;

--- a/tests/fill_queue_tests.rs
+++ b/tests/fill_queue_tests.rs
@@ -1,7 +1,6 @@
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
-
 use setup::{UmemConfigBuilder, Xsk};
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {

--- a/tests/rx_queue_tests.rs
+++ b/tests/rx_queue_tests.rs
@@ -1,4 +1,5 @@
 use libbpf_sys::XDP_PACKET_HEADROOM;
+use serial_test::serial;
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
@@ -43,6 +44,7 @@ fn default_config_builders() -> (UmemConfigBuilder, SocketConfigBuilder) {
 }
 
 #[tokio::test]
+#[serial]
 async fn rx_queue_consumes_nothing_if_no_tx_and_fill_q_empty() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         assert_eq!(dev1.rx_q.consume(&mut dev1.frame_descs[..2]), 0);
@@ -69,6 +71,7 @@ async fn rx_queue_consumes_nothing_if_no_tx_and_fill_q_empty() {
 }
 
 #[tokio::test]
+#[serial]
 async fn rx_queue_consume_returns_nothing_if_fill_q_empty() {
     fn test_fn(mut dev1: Xsk, mut dev2: Xsk) {
         assert_eq!(
@@ -104,6 +107,7 @@ async fn rx_queue_consume_returns_nothing_if_fill_q_empty() {
 }
 
 #[tokio::test]
+#[serial]
 async fn rx_queue_consumes_frame_correctly_after_tx() {
     fn test_fn(mut dev1: Xsk, mut dev2: Xsk) {
         // Add a frame in the dev1 fill queue ready to receive
@@ -160,6 +164,7 @@ async fn rx_queue_consumes_frame_correctly_after_tx() {
 }
 
 #[tokio::test]
+#[serial]
 async fn recvd_packet_offset_after_tx_includes_xdp_and_frame_headroom() {
     fn test_fn(mut dev1: Xsk, mut dev2: Xsk) {
         // Add a frame in the dev1 fill queue ready to receive

--- a/tests/rx_queue_tests.rs
+++ b/tests/rx_queue_tests.rs
@@ -2,7 +2,6 @@ use libbpf_sys::XDP_PACKET_HEADROOM;
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
-
 use setup::{SocketConfigBuilder, UmemConfigBuilder, Xsk};
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -4,8 +4,8 @@ use xsk_rs::{
 };
 
 mod veth_setup;
-mod xsk_setup;
 
+mod xsk_setup;
 pub use xsk_setup::{SocketConfigBuilder, UmemConfigBuilder};
 
 pub struct Xsk<'a> {
@@ -66,5 +66,5 @@ pub async fn run_test<F>(
         test(dev1_socket, dev2_socket)
     };
 
-    veth_setup::run_with_dev(inner).await;
+    veth_setup::run_with_dev(inner).await.unwrap();
 }

--- a/tests/tx_queue_tests.rs
+++ b/tests/tx_queue_tests.rs
@@ -1,7 +1,6 @@
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
-
 use setup::{SocketConfigBuilder, UmemConfigBuilder, Xsk};
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {

--- a/tests/tx_queue_tests.rs
+++ b/tests/tx_queue_tests.rs
@@ -1,3 +1,4 @@
+use serial_test::serial;
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
@@ -20,6 +21,7 @@ fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
 }
 
 #[tokio::test]
+#[serial]
 async fn tx_queue_produce_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let frame_descs = dev1.frame_descs;
@@ -41,6 +43,7 @@ async fn tx_queue_produce_tx_size_frames() {
 }
 
 #[tokio::test]
+#[serial]
 async fn tx_queue_produce_gt_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let frame_descs = dev1.frame_descs;
@@ -62,6 +65,7 @@ async fn tx_queue_produce_gt_tx_size_frames() {
 }
 
 #[tokio::test]
+#[serial]
 async fn tx_queue_produce_frames_until_tx_queue_full() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let frame_descs = dev1.frame_descs;


### PR DESCRIPTION
Don't create a differently named veth pair for each test, use the same name and set up / tear down between tests, and run tests sequentially to avoid conflicts. Avoids potentially multiple veth pairs lying around that require cleaning up if something goes wrong.