### PR TITLE
Try out a new interface for Umem and Frames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["AF_XDP", "XSK", "eBPF", "XDP"]
 
 [dependencies]
 bitflags = "1.2"
-libbpf-sys = "0.4.0-2"
+libbpf-sys = "0.6.0-1"
 libc = "0.2"
 log = "0.4"
 
@@ -20,14 +20,14 @@ anyhow = "1.0"
 clap = "2.33"
 crossbeam-channel = "0.5"
 ctrlc = "3.1"
-etherparse = "0.9"
+etherparse = "0.10"
 futures = "0.3"
 rand = "0.8"
-rtnetlink = "0.7"
-env_logger = "0.8"
+rtnetlink = "0.8"
+env_logger = "0.9"
 serial_test = "0.5"
 
 [dev-dependencies.tokio]
-version = "1.6"
+version = "1.15"
 default-features = false
 features =  ["rt-multi-thread", "macros", "sync", "signal", "time"]

--- a/examples/dev2_to_dev1.rs
+++ b/examples/dev2_to_dev1.rs
@@ -1,3 +1,9 @@
+fn main() {
+    todo!();
+    // ToDo: Update example
+}
+
+/*
 mod setup;
 
 use clap::{App, Arg};
@@ -22,6 +28,7 @@ use xsk_rs::{
 };
 
 use setup::{LinkIpAddr, VethConfig};
+use xsk_rs::umem::Frame;
 
 // Reqd for the multithreaded case to signal when all packets have
 // been sent
@@ -35,7 +42,7 @@ struct Xsk<'umem> {
     rx_q: RxQueue<'umem>,
     fill_q: FillQueue<'umem>,
     comp_q: CompQueue<'umem>,
-    frame_descs: Vec<FrameDesc<'umem>>,
+    frame_descs: Vec<Frame>,
     umem: Umem<'umem>,
 }
 
@@ -801,3 +808,4 @@ fn main() {
 
     veth_handle.join().unwrap();
 }
+*/

--- a/examples/hello_xdp.rs
+++ b/examples/hello_xdp.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use xsk_rs::umem::Frame;
 
 // Put umem at bottom so drop order is correct
-struct SocketState<'umem> {
-    fill_q: FillQueue<'umem>,
-    tx_q: TxQueue<'umem>,
-    rx_q: RxQueue<'umem>,
+struct SocketState {
+    fill_q: FillQueue,
+    tx_q: TxQueue,
+    rx_q: RxQueue,
     frames: Vec<Frame>,
 }
 

--- a/src/socket/socket.rs
+++ b/src/socket/socket.rs
@@ -101,6 +101,7 @@ impl Socket {
             xdp_flags: config.xdp_flags().bits(),
             bind_flags: config.bind_flags().bits(),
             libbpf_flags: config.libbpf_flags().bits(),
+            __bindgen_padding_0: [0; 2],
         };
 
         let mut xsk_ptr: *mut xsk_socket = ptr::null_mut();

--- a/src/socket/socket.rs
+++ b/src/socket/socket.rs
@@ -299,9 +299,16 @@ impl TxQueue<'_> {
             "Kernel should at maximum return the number of frames we asked for"
         );
 
+        let umem_mmap_area = self._socket.umem.mmap_area();
+
         if cnt > 0 {
             // ToDo: Check if drain is correct here
             for (idx, frame) in frames.drain(..cnt).enumerate() {
+                assert!(
+                    Arc::ptr_eq(frame.mmap_area(), umem_mmap_area),
+                    "a `Socket` can only take `Frame`s pointing into its `Umem`"
+                );
+
                 // Safety: ToDo
                 let idx: u32 = idx.try_into().expect("number of frames fits u32");
                 let send_pkt_desc = unsafe {

--- a/src/socket/socket.rs
+++ b/src/socket/socket.rs
@@ -5,7 +5,6 @@ use std::{
     error::Error,
     ffi::{CString, NulError},
     fmt, io,
-    marker::PhantomData,
     mem::MaybeUninit,
     ptr,
     sync::Arc,

--- a/src/umem/frame.rs
+++ b/src/umem/frame.rs
@@ -1,0 +1,232 @@
+use super::mmap::MmapArea;
+use crate::FrameDesc;
+use std::convert::TryInto;
+use std::fmt::{Debug, Formatter};
+use std::hash::{Hash, Hasher};
+use std::io::Write;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+use std::slice;
+use std::sync::Arc;
+
+// ToDo: Handle headroom
+
+/// An owned frame in a [super::Umem] [super::mmap::MmapArea]
+///
+/// ... Todo: just notes
+///
+/// * Frame owns a unique part of umem
+/// * Uninitialized bytes after the initialized parts can not be read (except with unsafe).
+///     * -> To make it imposible to read data of older packets.
+///
+/// The interface for this struct is influenced by
+/// [`heapless::Vec`](https://docs.rs/heapless/0.7.5/heapless/struct.Vec.html) as it also manages
+/// a variable length data slice in a fixed length allocation.
+pub struct Frame {
+    /// This reference makes sure that the underlying memory is still available
+    _mmap_area: Arc<MmapArea>,
+    base_ptr: NonNull<u8>,
+    capacity: usize,
+    desc: FrameDesc<'static>,
+}
+
+impl Frame {
+    /// Create a new Frame which lives in `mmap_area` and is described by `frame_desc`
+    ///
+    /// # Panic
+    /// If the length given in the descriptor is larger than the size of a frame in the `MmapArea`
+    /// this function panics. Or if the frame_desc points outside of the `MmapArea`.
+    ///
+    /// # Safety
+    /// `frame_desc` must point to a non-aliased region in `mmap_area`.
+    pub unsafe fn new(mmap_area: Arc<MmapArea>, desc: FrameDesc<'static>) -> Self {
+        assert!(desc.len() <= mmap_area.size.frame_size());
+        let capacity = mmap_area.size.frame_size();
+
+        let mmap_base = mmap_area.mem_ptr as *mut u8;
+        let base_ptr = mmap_base.offset(
+            desc.addr()
+                .try_into()
+                .expect("Offset does not fill up half of the address space"),
+        );
+
+        // Check base_ptr points into mmap area and is not null
+        let valid_range = (mmap_base as usize)
+            ..=(mmap_base.offset(
+                (mmap_area.size.total_bytes() - mmap_area.size.frame_size())
+                    .try_into()
+                    .expect("mmap does not fill half of the address space"),
+            ) as usize);
+        assert!(valid_range.contains(&(base_ptr as usize)));
+        let base_ptr = NonNull::new(base_ptr).expect("Mmap_area is non null");
+
+        Frame {
+            _mmap_area: mmap_area,
+            base_ptr,
+            capacity,
+            desc,
+        }
+    }
+
+    /// Set the size of the frame to 0
+    pub fn clear(&mut self) {
+        // Safety: 0 is always shorter as the initialized length
+        unsafe { self.set_len(0) };
+    }
+
+    /// Get a view of the initialized part of the Frame
+    pub fn as_slice(&self) -> &[u8] {
+        &self.full_cap_slice()[..self.len()]
+    }
+
+    /// Get a mutable view of the initialized parts of the Frame
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        let len = self.len();
+        &mut self.full_cap_slice_mut()[..len]
+    }
+
+    /// Get the number of initialized bytes
+    pub fn len(&self) -> usize {
+        self.desc.len()
+    }
+
+    /// Set the number of initialized bytes
+    ///
+    /// # Safety
+    /// * ToDo: may not expose unilitialized data
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.desc.set_len(new_len)
+    }
+
+    /// Add a byte to the end of the frame
+    pub fn push(&mut self, val: u8) -> Result<(), ()> {
+        let len = self.len();
+        if len == self.capacity {
+            return Err(());
+        }
+
+        self.full_cap_slice_mut()[len] = val;
+
+        // Safety: The new value was just initialized
+        unsafe { self.set_len(len + 1) };
+
+        Ok(())
+    }
+
+    /// Set the new length of the frame
+    ///
+    /// If the new size is larger then the old, the new bytes will be filled with zeroes.
+    pub fn resize(&mut self, new_size: usize) {
+        if new_size > self.len() {
+            let len = self.len();
+            self.full_cap_slice_mut()[len..new_size].fill(0);
+        }
+
+        // Safety: We just filled up the new space with zeroes so it is initialized
+        unsafe { self.set_len(new_size) };
+    }
+
+    /// Get the frame descriptor for this frame
+    pub fn frame_desc(&self) -> &FrameDesc {
+        &self.desc
+    }
+
+    /// Get a view to the full space available to the Frame including uninitialized bytes
+    fn full_cap_slice(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.base_ptr.as_ptr(), self.capacity) }
+    }
+
+    /// Get a mutable view to the full space available to the Frame including uninitialized bytes
+    fn full_cap_slice_mut(&mut self) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.base_ptr.as_ptr(), self.capacity) }
+    }
+}
+
+// Safety: We have unique ownership over the base_ptr. All other parts of the struct are auto Send
+unsafe impl Send for Frame {}
+
+// Safety: We do not use interior mutability, all mutations are performed through a &mut Frame
+unsafe impl Sync for Frame {}
+
+// Traits that cause Frame to behave similar to a &[u8] or a Vec<u8>
+impl Deref for Frame {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl DerefMut for Frame {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl AsRef<[u8]> for Frame {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+impl AsMut<[u8]> for Frame {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self
+    }
+}
+
+impl Write for Frame {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let len = self.len();
+        let mut target = &mut self.full_cap_slice_mut()[len..];
+
+        let written = target.write(buf)?;
+        // Safety: `target.write` initialized the new memory region
+        unsafe { self.set_len(len + written) };
+
+        assert!(self.len() <= self.capacity);
+
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Extend<u8> for Frame {
+    fn extend<T: IntoIterator<Item = u8>>(&mut self, iter: T) {
+        for val in iter {
+            match self.push(val) {
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+impl PartialEq for Frame {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for Frame {}
+
+impl PartialEq<&[u8]> for Frame {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.as_slice() == *other
+    }
+}
+
+impl Hash for Frame {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state)
+    }
+}
+
+impl Debug for Frame {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Frame").field(&self.as_slice()).finish()
+    }
+}

--- a/src/umem/frame.rs
+++ b/src/umem/frame.rs
@@ -159,6 +159,10 @@ impl Frame {
     pub fn mmap_area(&self) -> &Arc<MmapArea> {
         &self.mmap_area
     }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
 }
 
 // Safety: We have unique ownership over the base_ptr. All other parts of the struct are auto Send

--- a/src/umem/frame.rs
+++ b/src/umem/frame.rs
@@ -27,7 +27,7 @@ pub struct Frame {
     mmap_area: Arc<MmapArea>,
     base_ptr: NonNull<u8>,
     capacity: usize,
-    desc: FrameDesc<'static>,
+    desc: FrameDesc,
 }
 
 impl Frame {
@@ -39,7 +39,7 @@ impl Frame {
     ///
     /// # Safety
     /// `frame_desc` must point to a non-aliased region in `mmap_area`.
-    pub unsafe fn new(mmap_area: Arc<MmapArea>, desc: FrameDesc<'static>) -> Self {
+    pub unsafe fn new(mmap_area: Arc<MmapArea>, desc: FrameDesc) -> Self {
         assert!(desc.len() <= mmap_area.size.frame_size());
         let capacity = mmap_area.size.frame_size();
 

--- a/src/umem/mod.rs
+++ b/src/umem/mod.rs
@@ -1,8 +1,10 @@
 mod config;
+mod frame;
 mod mmap;
 mod umem;
 
 pub use config::{Config, ConfigError};
+pub use frame::Frame;
 pub use umem::{
     AccessError, CompQueue, DataError, FillQueue, FrameDesc, Umem, UmemBuilder,
     UmemBuilderWithMmap, WriteError,

--- a/src/umem/umem.rs
+++ b/src/umem/umem.rs
@@ -1,5 +1,5 @@
 use libbpf_sys::{xsk_ring_cons, xsk_ring_prod, xsk_umem, xsk_umem_config, XDP_PACKET_HEADROOM};
-use std::{convert::TryInto, error::Error, fmt, io, marker::PhantomData, mem::MaybeUninit, ptr};
+use std::{convert::TryInto, error::Error, fmt, io, mem::MaybeUninit, ptr};
 
 use crate::socket::{self, Fd};
 
@@ -282,10 +282,6 @@ impl Umem {
 
     pub(crate) fn as_ptr(&self) -> *const xsk_umem {
         self.inner.as_ref()
-    }
-
-    pub(crate) fn as_mut_ptr(&mut self) -> *mut xsk_umem {
-        self.inner.as_mut()
     }
 
     /// Check if trying to access the UMEM region bound by [`addr`,

--- a/tests/comp_queue_tests.rs
+++ b/tests/comp_queue_tests.rs
@@ -4,7 +4,6 @@ use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
 use setup::{SocketConfigBuilder, UmemConfigBuilder, Xsk};
-use std::collections::VecDeque;
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
     let umem_config = UmemConfigBuilder {
@@ -49,12 +48,12 @@ async fn num_frames_consumed_match_those_produced() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
         let mut dev1_frames = dev1.frames;
 
-        let mut frames_to_send = VecDeque::with_capacity(2);
+        let mut frames_to_send = Vec::with_capacity(2);
         for _ in 0..2 {
-            frames_to_send.push_back(dev1_frames.pop().expect("got enough frames"));
+            frames_to_send.push(dev1_frames.pop().expect("got enough frames"));
         }
-        dev1.tx_q.produce_and_wakeup(&mut frames_to_send).unwrap();
-        assert!(frames_to_send.is_empty());
+        let not_sent = dev1.tx_q.produce_and_wakeup(frames_to_send).unwrap();
+        assert!(not_sent.is_empty());
 
         // Wait briefly so we don't try to consume too early
         thread::sleep(Duration::from_millis(5));

--- a/tests/fill_queue_tests.rs
+++ b/tests/fill_queue_tests.rs
@@ -3,6 +3,8 @@ use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
 use setup::{UmemConfigBuilder, Xsk};
+use std::collections::VecDeque;
+use xsk_rs::umem::Frame;
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
     let umem_config = UmemConfigBuilder {
@@ -19,9 +21,11 @@ fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
 #[serial]
 async fn fill_queue_produce_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
-        let frame_descs = dev1.frame_descs;
+        let mut frames: VecDeque<Frame> = dev1.frames.into();
+        let old_len = frames.len();
+        dev1.fill_q.produce(&mut frames);
 
-        assert_eq!(unsafe { dev1.fill_q.produce(&frame_descs[..4]) }, 4);
+        assert_eq!(old_len - frames.len(), 4);
     }
 
     let (dev1_umem_config, dev1_socket_config) = build_configs();
@@ -41,9 +45,12 @@ async fn fill_queue_produce_tx_size_frames() {
 #[serial]
 async fn fill_queue_produce_gt_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
-        let frame_descs = dev1.frame_descs;
-
-        assert_eq!(unsafe { dev1.fill_q.produce(&frame_descs[..5]) }, 0);
+        let mut frames_to_fill = VecDeque::with_capacity(5);
+        for _ in 0..5 {
+            frames_to_fill.push_back(dev1.frames.pop().unwrap());
+        }
+        dev1.fill_q.produce(&mut frames_to_fill);
+        assert!(frames_to_fill.is_empty());
     }
 
     let (dev1_umem_config, dev1_socket_config) = build_configs();
@@ -59,11 +66,13 @@ async fn fill_queue_produce_gt_tx_size_frames() {
     .await;
 }
 
+// ToDo: Fix test
+/*
 #[tokio::test]
 #[serial]
 async fn fill_queue_produce_frames_until_full() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
-        let frame_descs = dev1.frame_descs;
+        let frame_descs = dev1.frames;
 
         assert_eq!(unsafe { dev1.fill_q.produce(&frame_descs[..2]) }, 2);
         assert_eq!(unsafe { dev1.fill_q.produce(&frame_descs[2..3]) }, 1);
@@ -83,3 +92,4 @@ async fn fill_queue_produce_frames_until_full() {
     )
     .await;
 }
+*/

--- a/tests/rx_queue_tests.rs
+++ b/tests/rx_queue_tests.rs
@@ -1,4 +1,3 @@
-use libbpf_sys::XDP_PACKET_HEADROOM;
 use serial_test::serial;
 use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -9,14 +9,14 @@ mod xsk_setup;
 use std::sync::Arc;
 pub use xsk_setup::{SocketConfigBuilder, UmemConfigBuilder};
 
-pub struct Xsk<'a> {
+pub struct Xsk {
     pub if_name: String,
-    pub fill_q: FillQueue<'a>,
-    pub comp_q: CompQueue<'a>,
-    pub tx_q: TxQueue<'a>,
-    pub rx_q: RxQueue<'a>,
+    pub fill_q: FillQueue,
+    pub comp_q: CompQueue,
+    pub tx_q: TxQueue,
+    pub rx_q: RxQueue,
     pub frames: Vec<Frame>,
-    pub umem: Arc<Umem<'a>>,
+    pub umem: Arc<Umem>,
 }
 
 pub async fn run_test<F>(

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -6,6 +6,7 @@ use xsk_rs::{
 mod veth_setup;
 
 mod xsk_setup;
+use std::sync::Arc;
 pub use xsk_setup::{SocketConfigBuilder, UmemConfigBuilder};
 
 pub struct Xsk<'a> {
@@ -14,8 +15,8 @@ pub struct Xsk<'a> {
     pub comp_q: CompQueue<'a>,
     pub tx_q: TxQueue<'a>,
     pub rx_q: RxQueue<'a>,
-    pub frame_descs: Vec<FrameDesc<'a>>,
-    pub umem: Umem<'a>,
+    pub frames: Vec<Frame>,
+    pub umem: Arc<Umem<'a>>,
 }
 
 pub async fn run_test<F>(
@@ -42,7 +43,7 @@ pub async fn run_test<F>(
             comp_q,
             tx_q,
             rx_q,
-            frame_descs,
+            frames: frame_descs,
             umem,
         };
 
@@ -59,7 +60,7 @@ pub async fn run_test<F>(
             comp_q,
             tx_q,
             rx_q,
-            frame_descs,
+            frames: frame_descs,
             umem,
         };
 

--- a/tests/setup/xsk_setup.rs
+++ b/tests/setup/xsk_setup.rs
@@ -70,9 +70,7 @@ impl SocketConfigBuilder {
     }
 }
 
-fn build_umem<'a>(
-    umem_config: Option<UmemConfig>,
-) -> (Arc<Umem<'a>>, FillQueue<'a>, CompQueue<'a>, Vec<Frame>) {
+fn build_umem(umem_config: Option<UmemConfig>) -> (Arc<Umem>, FillQueue, CompQueue, Vec<Frame>) {
     let config = match umem_config {
         Some(cfg) => cfg,
         None => UmemConfigBuilder::default().build(),
@@ -91,13 +89,8 @@ pub fn build_socket_and_umem<'a, 'umem>(
     if_name: &'a str,
     queue_id: u32,
 ) -> (
-    (
-        Arc<Umem<'umem>>,
-        FillQueue<'umem>,
-        CompQueue<'umem>,
-        Vec<Frame>,
-    ),
-    (TxQueue<'umem>, RxQueue<'umem>),
+    (Arc<Umem>, FillQueue, CompQueue, Vec<Frame>),
+    (TxQueue, RxQueue),
 ) {
     let socket_config = match socket_config {
         Some(cfg) => cfg,

--- a/tests/tx_queue_tests.rs
+++ b/tests/tx_queue_tests.rs
@@ -3,6 +3,7 @@ use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
 use setup::{SocketConfigBuilder, UmemConfigBuilder, Xsk};
+use std::collections::VecDeque;
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
     let umem_config = UmemConfigBuilder {
@@ -24,9 +25,13 @@ fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
 #[serial]
 async fn tx_queue_produce_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
-        let frame_descs = dev1.frame_descs;
+        let mut frames_to_send = VecDeque::with_capacity(4);
+        for _ in 0..4 {
+            frames_to_send.push_back(dev1.frames.pop().unwrap());
+        }
 
-        assert_eq!(unsafe { dev1.tx_q.produce(&frame_descs[..4]) }, 4);
+        dev1.tx_q.produce(&mut frames_to_send);
+        assert!(frames_to_send.is_empty());
     }
 
     let (dev1_umem_config, dev1_socket_config) = build_configs();
@@ -41,12 +46,13 @@ async fn tx_queue_produce_tx_size_frames() {
     )
     .await;
 }
-
+// ToDo: Fix tests
+/*
 #[tokio::test]
 #[serial]
 async fn tx_queue_produce_gt_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
-        let frame_descs = dev1.frame_descs;
+        let frame_descs = dev1.frames;
 
         assert_eq!(unsafe { dev1.tx_q.produce(&frame_descs[..5]) }, 0);
     }
@@ -68,7 +74,7 @@ async fn tx_queue_produce_gt_tx_size_frames() {
 #[serial]
 async fn tx_queue_produce_frames_until_tx_queue_full() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
-        let frame_descs = dev1.frame_descs;
+        let frame_descs = dev1.frames;
 
         assert_eq!(unsafe { dev1.tx_q.produce(&frame_descs[..2]) }, 2);
         assert_eq!(unsafe { dev1.tx_q.produce(&frame_descs[2..3]) }, 1);
@@ -88,3 +94,4 @@ async fn tx_queue_produce_frames_until_tx_queue_full() {
     )
     .await;
 }
+*/

--- a/tests/tx_queue_tests.rs
+++ b/tests/tx_queue_tests.rs
@@ -3,7 +3,6 @@ use xsk_rs::{socket::Config as SocketConfig, umem::Config as UmemConfig};
 
 mod setup;
 use setup::{SocketConfigBuilder, UmemConfigBuilder, Xsk};
-use std::collections::VecDeque;
 
 fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
     let umem_config = UmemConfigBuilder {
@@ -25,13 +24,13 @@ fn build_configs() -> (Option<UmemConfig>, Option<SocketConfig>) {
 #[serial]
 async fn tx_queue_produce_tx_size_frames() {
     fn test_fn(mut dev1: Xsk, _dev2: Xsk) {
-        let mut frames_to_send = VecDeque::with_capacity(4);
+        let mut frames_to_send = Vec::with_capacity(4);
         for _ in 0..4 {
-            frames_to_send.push_back(dev1.frames.pop().unwrap());
+            frames_to_send.push(dev1.frames.pop().unwrap());
         }
 
-        dev1.tx_q.produce(&mut frames_to_send);
-        assert!(frames_to_send.is_empty());
+        let not_sent = dev1.tx_q.produce(frames_to_send);
+        assert!(not_sent.is_empty());
     }
 
     let (dev1_umem_config, dev1_socket_config) = build_configs();


### PR DESCRIPTION
This should make it easier to handle Frames living in Umem similar
to a Box<[u8]>. Frames now own the MmapArea in which they live via
a shared Arc.

This is not yet finished as all the tests and dev1_to_dev2 examples
still need to be converted to the new interface. But it should give
an a idea of how a new interface could look like.