### PR TITLE
Update docs

### DIFF
--- a/src/umem/frame/mod.rs
+++ b/src/umem/frame/mod.rs
@@ -146,9 +146,7 @@ impl Deref for Headroom<'_> {
     }
 }
 
-/// Mutable headroom segment of a [`Umem`](crate::umem::Umem) frame
-/// that allows writing via its [`cursor`](HeadroomMut::cursor)
-/// method.
+/// Mutable headroom segment of a [`Umem`](crate::umem::Umem) frame.
 #[derive(Debug)]
 pub struct HeadroomMut<'umem> {
     len: &'umem mut usize,
@@ -166,13 +164,21 @@ impl<'umem> HeadroomMut<'umem> {
         &self.buf[..*self.len]
     }
 
-    /// Returns a mutable view of this segment's contents, up to its current length.
+    /// Returns a mutable view of this segment's contents, up to its
+    /// current length.
     #[inline]
     pub fn contents_mut(&mut self) -> &mut [u8] {
         &mut self.buf[..*self.len]
     }
 
     /// A cursor for writing to this segment.
+    ///
+    /// Modifications via the cursor will change the length of the
+    /// segment, i.e. the headroom length of the frame descriptor. If
+    /// in-place modifications just need to be made then
+    /// [`contents_mut`] may be sufficient.
+    ///
+    /// [`contents_mut`]: Self::contents_mut
     #[inline]
     pub fn cursor(&mut self) -> Cursor<'_> {
         Cursor::new(self.len, self.buf)
@@ -266,8 +272,8 @@ impl Deref for Data<'_> {
     }
 }
 
-/// Mutable data segment of a [`Umem`](crate::umem::Umem) frame that
-/// allows writing via its [`cursor`](DataMut::cursor) method.
+/// Mutable packet data segment of a [`Umem`](crate::umem::Umem)
+/// frame.
 #[derive(Debug)]
 pub struct DataMut<'umem> {
     len: &'umem mut usize,
@@ -287,7 +293,8 @@ impl<'umem> DataMut<'umem> {
         &self.buf[..*self.len]
     }
 
-    /// Returns a mutable view of this segment's contents, up to its current length.
+    /// Returns a mutable view of this segment's contents, up to its
+    /// current length.
     ///
     /// Will change as packets are sent or received using this frame.
     #[inline]
@@ -295,7 +302,15 @@ impl<'umem> DataMut<'umem> {
         &mut self.buf[..*self.len]
     }
 
-    /// A cursor for writing to the underlying memory.
+    /// A cursor for writing to this segment.
+    ///
+    /// Modifications via the cursor will change the length of the
+    /// segment, i.e. the data length of the frame descriptor, and in
+    /// this case the size of the packet that will be submitted. If
+    /// in-place modifications just need to be made then
+    /// [`contents_mut`] may be sufficient.
+    ///
+    /// [`contents_mut`]: Self::contents_mut
     #[inline]
     pub fn cursor(&mut self) -> Cursor<'_> {
         Cursor::new(self.len, self.buf)

--- a/src/umem/mod.rs
+++ b/src/umem/mod.rs
@@ -98,7 +98,7 @@ pub struct Umem {
 }
 
 impl Umem {
-    /// Create a new [`Umem`] instance backed by an anonymous memory
+    /// Create a new `Umem` instance backed by an anonymous memory
     /// mapped region.
     ///
     /// Setting `use_huge_pages` to `true` will instructed `mmap()` to
@@ -193,15 +193,26 @@ impl Umem {
         Ok((umem, frame_descs))
     }
 
-    /// The headroom and packet data segments of the [`Umem`] frame
+    /// The headroom and packet data segments of the `Umem` frame
     /// pointed at by `desc`. Contents are read-only.
     ///
     /// # Safety
     ///
     /// `desc` must correspond to a frame belonging to this
-    /// [`Umem`]. Furthermore, the memory region accessed must not be
-    /// mutably accessed anywhere else at the same time, either in
-    /// userspace or by the kernel.
+    /// `Umem`. Passing the descriptor of another `Umem` is very
+    /// likely to result in incorrect memory access, by either
+    /// straddling frames or accessing memory outside the underlying
+    /// `Umem` area.
+    ///
+    /// Furthermore, the memory region accessed must not be mutably
+    /// accessed anywhere else at the same time, either in userspace
+    /// or by the kernel. To ensure this, care should be taken not to
+    /// use the frame after submission to either the [`TxQueue`] or
+    /// [`FillQueue`] until received over the [`CompQueue`] or
+    /// [`RxQueue`] respectively.
+    ///
+    /// [`TxQueue`]: crate::TxQueue
+    /// [`RxQueue`]: crate::RxQueue
     #[inline]
     pub unsafe fn frame(&self, desc: &FrameDesc) -> (Headroom, Data) {
         // SAFETY: We know from the unsafe contract of this function that:
@@ -212,7 +223,7 @@ impl Umem {
         unsafe { self.mem.frame(desc) }
     }
 
-    /// The headroom segment of the [`Umem`] frame pointed at by
+    /// The headroom segment of the `Umem` frame pointed at by
     /// `desc`. Contents are read-only.
     ///
     /// # Safety
@@ -224,7 +235,7 @@ impl Umem {
         unsafe { self.mem.headroom(desc) }
     }
 
-    /// The data segment of the [`Umem`] frame pointed at by
+    /// The data segment of the `Umem` frame pointed at by
     /// `desc`. Contents are read-only.
     ///
     /// # Safety
@@ -236,15 +247,26 @@ impl Umem {
         unsafe { self.mem.data(desc) }
     }
 
-    /// The headroom and packet data segments of the [`Umem`] frame
+    /// The headroom and packet data segments of the `Umem` frame
     /// pointed at by `desc`. Contents are writeable.
     ///
     /// # Safety
     ///
     /// `desc` must correspond to a frame belonging to this
-    /// [`Umem`]. Furthermore, the memory region accessed must not be
-    /// mutably or immutably accessed anywhere else at the same time,
-    /// either in userspace or by the kernel.
+    /// `Umem`. Passing the descriptor of another `Umem` is very
+    /// likely to result in incorrect memory access, by either
+    /// straddling frames or accessing memory outside the underlying
+    /// `Umem` area.
+    ///
+    /// Furthermore, the memory region accessed must not be mutably or
+    /// immutably accessed anywhere else at the same time, either in
+    /// userspace or by the kernel. To ensure this, care should be
+    /// taken not to use the frame after submission to either the
+    /// [`TxQueue`] or [`FillQueue`] until received over the
+    /// [`CompQueue`] or [`RxQueue`] respectively.
+    ///
+    /// [`TxQueue`]: crate::TxQueue
+    /// [`RxQueue`]: crate::RxQueue
     #[inline]
     pub unsafe fn frame_mut<'a>(
         &'a self,
@@ -258,7 +280,7 @@ impl Umem {
         unsafe { self.mem.frame_mut(desc) }
     }
 
-    /// The headroom segment of the [`Umem`] frame pointed at by
+    /// The headroom segment of the `Umem` frame pointed at by
     /// `desc`. Contents are writeable.
     ///
     /// # Safety
@@ -270,7 +292,7 @@ impl Umem {
         unsafe { self.mem.headroom_mut(desc) }
     }
 
-    /// The data segment of the [`Umem`] frame pointed at by
+    /// The data segment of the `Umem` frame pointed at by
     /// `desc`. Contents are writeable.
     ///
     /// # Safety


### PR DESCRIPTION
clarify safety section in `Umem::frame` and `Umem::frame_mut` docs, add some colour on `{Headroom,Data}Mut::cursor` vs `{Headroom, Data}Mut::contents_mut`