### PR TITLE
Translate error codes to errno by inverting

### DIFF
--- a/src/socket/fd.rs
+++ b/src/socket/fd.rs
@@ -101,7 +101,7 @@ impl Fd {
         };
 
         if err != 0 {
-            return Err(io::Error::from_raw_os_error(err));
+            return Err(io::Error::last_os_error());
         }
 
         if optlen == XDP_STATISTICS_SIZEOF {

--- a/src/umem/mem/mmap.rs
+++ b/src/umem/mem/mmap.rs
@@ -68,9 +68,8 @@ mod inner {
 
             if err != 0 {
                 error!(
-                    "`munmap()` failed with error code {}, errno {}",
-                    err,
-                    std::io::Error::last_os_error()
+                    "`munmap()` failed with error: {}",
+                    io::Error::last_os_error()
                 );
             }
         }

--- a/src/umem/mem/mmap.rs
+++ b/src/umem/mem/mmap.rs
@@ -67,7 +67,11 @@ mod inner {
             let err = unsafe { libc::munmap(self.addr.as_ptr(), self.len) };
 
             if err != 0 {
-                error!("`munmap()` failed with error code {}", err);
+                error!(
+                    "`munmap()` failed with error code {}, errno {}",
+                    err,
+                    std::io::Error::last_os_error()
+                );
             }
         }
     }


### PR DESCRIPTION
This allows `std::io::Error::from_raw_os_error` to translate the
number to an error name.

---

Thanks again for creating the library. I had another try with it and it works great :) the only small "pain-point" I had was that the error codes returned for some of the system calls were not translated because they were negative. I think this PR should fix this.

Also is there a reason why `FrameDesc` does not implement `Default`? I needed some `FrameDesc`s when fetching packets. I solved it by just keeping a copy of one of the original `FrameDesc`s around in my `struct`.