### PR TITLE
mark Socket::new as unsafe

### DIFF
--- a/examples/dev1_to_dev2.rs
+++ b/examples/dev1_to_dev2.rs
@@ -598,8 +598,9 @@ pub fn build_socket_and_umem(
 ) -> Xsk {
     let (umem, frames) = Umem::new(umem_config, frame_count, false).expect("failed to build umem");
 
-    let (tx_q, rx_q, fq_and_cq) =
-        Socket::new(socket_config, &umem, if_name, queue_id).expect("failed to build socket");
+    let (tx_q, rx_q, fq_and_cq) = unsafe {
+        Socket::new(socket_config, &umem, if_name, queue_id).expect("failed to build socket")
+    };
 
     let (fq, cq) = fq_and_cq.expect(&format!(
         "missing fill and comp queue - interface {:?} may already be bound to",

--- a/examples/hello_xdp.rs
+++ b/examples/hello_xdp.rs
@@ -17,12 +17,14 @@ fn hello_xdp(dev1: (VethDevConfig, PacketGenerator), dev2: (VethDevConfig, Packe
 
     // Bind an AF_XDP socket to the interface named `xsk_dev1`, on
     // queue 0.
-    let (mut dev1_tx_q, _dev1_rx_q, _dev1_fq_and_cq) = Socket::new(
-        SocketConfig::default(),
-        &dev1_umem,
-        &dev1.0.if_name().parse().unwrap(),
-        0,
-    )
+    let (mut dev1_tx_q, _dev1_rx_q, _dev1_fq_and_cq) = unsafe {
+        Socket::new(
+            SocketConfig::default(),
+            &dev1_umem,
+            &dev1.0.if_name().parse().unwrap(),
+            0,
+        )
+    }
     .expect("failed to create dev1 socket");
 
     // Create a UMEM for dev2.
@@ -32,12 +34,14 @@ fn hello_xdp(dev1: (VethDevConfig, PacketGenerator), dev2: (VethDevConfig, Packe
 
     // Bind an AF_XDP socket to the interface named `xsk_dev2`, on
     // queue 0.
-    let (_dev2_tx_q, mut dev2_rx_q, dev2_fq_and_cq) = Socket::new(
-        SocketConfig::default(),
-        &dev2_umem,
-        &dev2.0.if_name().parse().unwrap(),
-        0,
-    )
+    let (_dev2_tx_q, mut dev2_rx_q, dev2_fq_and_cq) = unsafe {
+        Socket::new(
+            SocketConfig::default(),
+            &dev2_umem,
+            &dev2.0.if_name().parse().unwrap(),
+            0,
+        )
+    }
     .expect("failed to create dev2 socket");
 
     let (mut dev2_fq, _dev2_cq) = dev2_fq_and_cq.expect("missing dev2 fill queue and comp queue");

--- a/examples/shared_umem.rs
+++ b/examples/shared_umem.rs
@@ -16,22 +16,26 @@ fn hello_xdp(dev1: (VethDevConfig, PacketGenerator), dev2: (VethDevConfig, Packe
 
     // Bind an AF_XDP socket to the interface named `xsk_dev1`, on
     // queue 0.
-    let (mut dev1_tx_q, _dev1_rx_q, _dev1_fq_and_cq) = Socket::new(
-        SocketConfig::default(),
-        &umem,
-        &dev1.0.if_name().parse().unwrap(),
-        0,
-    )
+    let (mut dev1_tx_q, _dev1_rx_q, _dev1_fq_and_cq) = unsafe {
+        Socket::new(
+            SocketConfig::default(),
+            &umem,
+            &dev1.0.if_name().parse().unwrap(),
+            0,
+        )
+    }
     .expect("failed to create dev1 socket");
 
     // Bind an AF_XDP socket to the interface named `xsk_dev2`, on
     // queue 0. Also uses the UMEM above.
-    let (_dev2_tx_q, mut dev2_rx_q, dev2_fq_and_cq) = Socket::new(
-        SocketConfig::default(),
-        &umem,
-        &dev2.0.if_name().parse().unwrap(),
-        0,
-    )
+    let (_dev2_tx_q, mut dev2_rx_q, dev2_fq_and_cq) = unsafe {
+        Socket::new(
+            SocketConfig::default(),
+            &umem,
+            &dev2.0.if_name().parse().unwrap(),
+            0,
+        )
+    }
     .expect("failed to create dev2 socket");
 
     let (mut dev2_fq, _dev2_cq) = dev2_fq_and_cq.expect("missing dev2 fill queue and comp queue");

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -103,9 +103,16 @@ impl Socket {
     ///
     /// For further details on using a shared [`Umem`] please see the
     /// [docs](https://www.kernel.org/doc/html/latest/networking/af_xdp.html#xdp-shared-umem-bind-flag).
+    ///
+    /// # Safety
+    ///
+    /// If sharing the [`Umem`] and the `(if_name, queue_id)` pair is already bound to, then the
+    /// [`XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD`] flag must be set.
+    ///
+    /// [`XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD`]: crate::config::LibxdpFlags::XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD
     #[allow(clippy::new_ret_no_self)]
     #[allow(clippy::type_complexity)]
-    pub fn new(
+    pub unsafe fn new(
         config: SocketConfig,
         umem: &Umem,
         if_name: &Interface,

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -58,8 +58,9 @@ pub fn build_socket_and_umem(
 ) -> Xsk {
     let (umem, descs) = Umem::new(umem_config, frame_count, false).expect("failed to build umem");
 
-    let (tx_q, rx_q, fq_and_cq) =
-        Socket::new(socket_config, &umem, if_name, queue_id).expect("failed to build socket");
+    let (tx_q, rx_q, fq_and_cq) = unsafe {
+        Socket::new(socket_config, &umem, if_name, queue_id).expect("failed to build socket")
+    };
 
     let (fq, cq) = fq_and_cq.expect(&format!(
         "missing fill and comp queue - interface {:?} may already be bound to",

--- a/tests/umem_tests.rs
+++ b/tests/umem_tests.rs
@@ -25,12 +25,14 @@ async fn shared_umem_returns_new_fq_and_cq_when_sockets_are_bound_to_different_d
         let mut sender_descs = descs;
         let receiver_descs = sender_descs.drain((frame_count / 2) as usize..).collect();
 
-        let (sender_tx_q, sender_rx_q, sender_fq_and_cq) = Socket::new(
-            SocketConfig::default(),
-            &umem,
-            &dev1_config.if_name().parse().unwrap(),
-            0,
-        )
+        let (sender_tx_q, sender_rx_q, sender_fq_and_cq) = unsafe {
+            Socket::new(
+                SocketConfig::default(),
+                &umem,
+                &dev1_config.if_name().parse().unwrap(),
+                0,
+            )
+        }
         .unwrap();
 
         let (sender_fq, sender_cq) = sender_fq_and_cq.unwrap();
@@ -44,12 +46,14 @@ async fn shared_umem_returns_new_fq_and_cq_when_sockets_are_bound_to_different_d
             descs: sender_descs,
         };
 
-        let (receiver_tx_q, receiver_rx_q, receiver_fq_and_cq) = Socket::new(
-            SocketConfig::default(),
-            &umem,
-            &dev2_config.if_name().parse().unwrap(),
-            0,
-        )
+        let (receiver_tx_q, receiver_rx_q, receiver_fq_and_cq) = unsafe {
+            Socket::new(
+                SocketConfig::default(),
+                &umem,
+                &dev2_config.if_name().parse().unwrap(),
+                0,
+            )
+        }
         .unwrap();
 
         let (receiver_fq, receiver_cq) = receiver_fq_and_cq.unwrap();
@@ -80,26 +84,30 @@ async fn shared_umem_does_not_return_new_fq_and_cq_when_sockets_are_bound_to_sam
         let (umem, _frames) =
             Umem::new(UmemConfig::default(), 64.try_into().unwrap(), false).unwrap();
 
-        let (_sender_tx_q, _sender_rx_q, sender_fq_and_cq) = Socket::new(
-            SocketConfig::builder()
-                .libxdp_flags(LibxdpFlags::XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD)
-                .build(),
-            &umem,
-            &dev1_config.if_name().parse().unwrap(),
-            0,
-        )
+        let (_sender_tx_q, _sender_rx_q, sender_fq_and_cq) = unsafe {
+            Socket::new(
+                SocketConfig::builder()
+                    .libxdp_flags(LibxdpFlags::XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD)
+                    .build(),
+                &umem,
+                &dev1_config.if_name().parse().unwrap(),
+                0,
+            )
+        }
         .unwrap();
 
         assert!(sender_fq_and_cq.is_some());
 
-        let (_receiver_tx_q, _receiver_rx_q, receiver_fq_and_cq) = Socket::new(
-            SocketConfig::builder()
-                .libxdp_flags(LibxdpFlags::XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD)
-                .build(),
-            &umem,
-            &dev1_config.if_name().parse().unwrap(),
-            0,
-        )
+        let (_receiver_tx_q, _receiver_rx_q, receiver_fq_and_cq) = unsafe {
+            Socket::new(
+                SocketConfig::builder()
+                    .libxdp_flags(LibxdpFlags::XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD)
+                    .build(),
+                &umem,
+                &dev1_config.if_name().parse().unwrap(),
+                0,
+            )
+        }
         .unwrap();
 
         assert!(receiver_fq_and_cq.is_none());


### PR DESCRIPTION
to ensure XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD is set if sharing a UMEM and binding to an already bound (if_name, queue_id) pair