### PR TITLE
examples/dev1_to_dev2.rs: Use sender CQ size to calculate sender frame count

### DIFF
--- a/examples/dev1_to_dev2.rs
+++ b/examples/dev1_to_dev2.rs
@@ -622,7 +622,6 @@ fn build_umem_and_socket_config(config: &XskConfig) -> (UmemConfig, SocketConfig
         .frame_size(config.frame_size)
         .fill_queue_size(config.fq_size)
         .comp_queue_size(config.cq_size)
-        .frame_size(config.frame_size)
         .build()
         .unwrap();
 

--- a/examples/dev1_to_dev2.rs
+++ b/examples/dev1_to_dev2.rs
@@ -62,7 +62,7 @@ impl From<Opt> for Config {
             rx_q_size: opt.rx_q_size_sender.try_into().unwrap(),
             cq_size: opt.cq_size_sender.try_into().unwrap(),
             fq_size: opt.fq_size_sender.try_into().unwrap(),
-            frame_count: opt.fq_size_sender + opt.cq_size_receiver,
+            frame_count: opt.fq_size_sender + opt.cq_size_sender,
             frame_size: opt.frame_size_sender.try_into().unwrap(),
         };
 


### PR DESCRIPTION
Use *sender* CQ size for sender config, instead of receiver - possible typo?