### PR TITLE
add missing lifetime for umem::fame::Data::contents

### DIFF
--- a/src/umem/frame/mod.rs
+++ b/src/umem/frame/mod.rs
@@ -266,7 +266,7 @@ impl<'umem> Data<'umem> {
     ///
     /// Will change as packets are sent or received using this frame.
     #[inline]
-    pub fn contents(&self) -> &[u8] {
+    pub fn contents(&self) -> &'umem [u8] {
         self.contents
     }
 }


### PR DESCRIPTION
Currently, it is not possible to return the bytes of an Umem segment in a method:
```rust
fn test<'a>(umem: &'a mut Umem, frame: FrameDesc) -> &'a [u8] {
    let data = unsafe { umem.data(&frame) };
    data.contents()
}
```
(fails to compile:  `data does not live long enough`)

This PR fixes the issue by allowing the referenced Umem segment to outlive the `Data` instance.


