### PR TITLE
support for 32bit unix targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["AF_XDP", "XSK", "eBPF", "XDP"]
 bitflags = "2.9.0"
 cfg-if = "1.0.0"
 libc = "0.2.171"
-libxdp-sys = "0.2.2"
+libxdp-sys = "0.2.4"
 log = "0.4.27"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,5 +144,29 @@ cfg_if! {
                 assert_eq!(mem::size_of::<usize>(), mem::size_of::<u64>());
             }
         }
+    } else if #[cfg(all(target_pointer_width = "32", target_family = "unix"))] {
+        pub mod umem;
+        pub use umem::{frame::FrameDesc, CompQueue, FillQueue, Umem};
+
+        pub mod socket;
+        pub use socket::{RxQueue, Socket, TxQueue};
+
+        pub mod config;
+
+        mod ring;
+        mod util;
+
+        #[cfg(test)]
+        mod tests {
+            use std::mem;
+
+            #[test]
+            fn ensure_usize_fits_in_u64() {
+                // On 32-bit: usize is 4 bytes, u64 is 8 bytes.
+                // AF_XDP addr fields use u64 but store UMEM offsets (always < 4 GB),
+                // so a 32-bit usize zero-extends safely into u64.
+                assert!(mem::size_of::<usize>() < mem::size_of::<u64>());
+            }
+        }
     }
 }


### PR DESCRIPTION
Problem                                                                                                                                                                                   
                                                                                                                                                                                            
  On 32-bit unix targets (e.g. armv7), the entire public API is gated behind:                                                                                                               
                                                                                                                                                                                            
  if #[cfg(all(target_pointer_width = "64", target_family = "unix"))]

  so nothing is exported. Any crate depending on xsk-rs fails to compile with errors like:

  error[E0432]: unresolved import `xsk_rs::config`
  error[E0432]: unresolved import `xsk_rs::Umem`
  ... (7 total)

  Change

  Add an else if branch for target_pointer_width = "32" exposing the same public API. The 64-bit branch is unchanged.

  Why the usize↔u64 casts are safe on 32-bit

  The addr field in AF_XDP descriptors is a byte offset into UMEM, not an absolute pointer. UMEM is a user-space mmap buffer — always within the 32-bit virtual address space. All casts are
   therefore safe:

  - fill_queue.rs:65,92, cast usize → u64, zero-extension, lossless 
  - comp_queue.rs:60,90, cast u64 → usize, UMEM offsets always < 4 GB
  - frame/mod.rs:102, cast usize → u64, zero-extension, lossless

  The new ensure_usize_fits_in_u64 test documents and asserts this invariant.

  Testing

  Tested building for armv7-unknown-linux-gnueabihf (cortexa7, Yocto cross-compilation environment) — previously compile errors, now builds cleanly.