### PR TITLE
feat: expose UMEM and frame descriptor APIs

### DIFF
--- a/src/umem/frame/mod.rs
+++ b/src/umem/frame/mod.rs
@@ -67,7 +67,7 @@ impl FrameDesc {
     ///
     /// `addr` must be the starting address of the packet data segment
     /// of some [`Umem`](super::Umem) frame.
-    pub(super) fn new(addr: usize) -> Self {
+    pub fn new(addr: usize) -> Self {
         Self {
             addr,
             options: 0,
@@ -75,6 +75,18 @@ impl FrameDesc {
         }
     }
 
+    /// Replaces the default options with the provided value.
+    pub fn with_options(mut self, options: u32) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Replaces the default segment lengths.
+    pub fn with_lengths(mut self, headroom: usize, data: usize) -> Self {
+        self.lengths = SegmentLengths { headroom, data };
+        self
+    }
+    
     /// The starting address of the packet data segment of the frame
     /// pointed at by this descriptor.
     #[inline]

--- a/src/umem/mod.rs
+++ b/src/umem/mod.rs
@@ -421,6 +421,13 @@ impl Umem {
         // SAFETY: guaranteed by this function's contract.
         unsafe { libxdp_sys::xsk_socket__delete(ptr) };
     }
+
+    /// Returns a raw pointer to the beginning of the UMEM buffer
+    /// (for use cases like memory mapping, e.g., WebAssembly)
+    #[inline(always)]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.mem.as_ptr() as *const u8
+    }
 }
 
 /// What libxdp did with the fill and comp rings it was handed when


### PR DESCRIPTION
- Make FrameDesc::new publicly accessible
- Add FrameDesc option and length builders
- Expose the base pointer of an Umem buffer

These changes are required for use cases which need to (re-)construct FrameDesc and/or need access to the Umem base pointer.