### PR TITLE
feat: expose queue capacity and availability helpers

### DIFF
--- a/src/socket/rx_queue.rs
+++ b/src/socket/rx_queue.rs
@@ -159,4 +159,18 @@ impl RxQueue {
     pub fn fd_mut(&mut self) -> &mut Fd {
         &mut self.socket.fd
     }
+
+    /// Returns the number of items currently available in the RX queue.
+    ///
+    /// This can be used to check how many received packets are ready to be consumed
+    /// without actually consuming them.
+    ///
+    /// # Arguments
+    ///
+    /// * `desired` - The maximum number of items you want to check for. The return value
+    ///  will be min(desired, actual_available).
+    #[inline]
+    pub fn nb_avail(&mut self, desired: u32) -> u32 {
+        unsafe { libxdp_sys::xsk_cons_nb_avail(self.ring.as_ptr(), desired) }
+    }
 }

--- a/src/socket/tx_queue.rs
+++ b/src/socket/tx_queue.rs
@@ -205,4 +205,18 @@ impl TxQueue {
     pub fn fd_mut(&mut self) -> &mut Fd {
         &mut self.socket.fd
     }
+
+    /// Returns the number of free slots available in the TX queue.
+    ///
+    /// This can be used to check how many frames can be produced (submitted)
+    /// to the TX queue without blocking.
+    ///
+    /// # Arguments
+    ///
+    /// * `desired` - The maximum number of free slots you want to check for. The return value
+    ///  will be min(desired, actual_free_slots).
+    #[inline]
+    pub fn nb_free(&mut self, desired: u32) -> u32 {
+        unsafe { libxdp_sys::xsk_prod_nb_free(self.ring.as_ptr(), desired) }
+    }
 }

--- a/src/umem/comp_queue.rs
+++ b/src/umem/comp_queue.rs
@@ -108,4 +108,18 @@ impl CompQueue {
 
         cnt as usize
     }
+
+    /// Returns the number of items currently available in the completion queue.
+    ///
+    /// This can be used to check how many completed TX frames are ready to be consumed
+    /// without actually consuming them.
+    ///
+    /// # Arguments
+    ///
+    /// * `desired` - The maximum number of items you want to check for. The return value
+    ///  will be min(desired, actual_available).
+    #[inline]
+    pub fn nb_avail(&mut self, desired: u32) -> u32 {
+        unsafe { libxdp_sys::xsk_cons_nb_avail(self.ring.as_ptr(), desired) }
+    }
 }

--- a/src/umem/fill_queue.rs
+++ b/src/umem/fill_queue.rs
@@ -192,4 +192,18 @@ impl FillQueue {
     pub fn needs_wakeup(&self) -> bool {
         unsafe { libxdp_sys::xsk_ring_prod__needs_wakeup(self.ring.as_ptr()) != 0 }
     }
+
+    /// Returns the number of free slots available in the fill queue.
+    ///
+    /// This can be used to check how many frames can be produced (submitted)
+    /// to the fill queue without blocking.
+    ///
+    /// # Arguments
+    ///
+    /// * `desired` - The maximum number of free slots you want to check for. The return value
+    ///   will be min(desired, actual_free_slots).
+    #[inline]
+    pub fn nb_free(&mut self, desired: u32) -> u32 {
+        unsafe { libxdp_sys::xsk_prod_nb_free(self.ring.as_ptr(), desired) }
+    }
 }

--- a/tests/comp_queue_tests.rs
+++ b/tests/comp_queue_tests.rs
@@ -185,6 +185,37 @@ async fn frame_consumed_with_consume_one_should_match_addr_of_one_produced() {
     build_configs_and_run_test(test).await
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn nb_avail_reports_completed_tx_frames_and_honors_desired() {
+    fn test(dev1: (Xsk, PacketGenerator), _dev2: (Xsk, PacketGenerator)) {
+        let mut xsk1 = dev1.0;
+
+        assert_eq!(xsk1.cq.nb_avail(CQ_SIZE), 0);
+
+        for desc in &mut xsk1.descs[..2] {
+            unsafe {
+                xsk1.umem
+                    .data_mut(desc)
+                    .cursor()
+                    .write_all(&ETHERNET_PACKET[..])
+                    .unwrap();
+            }
+        }
+
+        assert_eq!(
+            unsafe { xsk1.tx_q.produce_and_wakeup(&xsk1.descs[..2]).unwrap() },
+            2
+        );
+        thread::sleep(Duration::from_millis(5));
+
+        assert_eq!(xsk1.cq.nb_avail(1), 1);
+        assert_eq!(xsk1.cq.nb_avail(CQ_SIZE), 2);
+    }
+
+    build_configs_and_run_test(test).await
+}
+
 async fn build_configs_and_run_test<F>(test: F)
 where
     F: Fn((Xsk, PacketGenerator), (Xsk, PacketGenerator)) + Send + 'static,

--- a/tests/fill_queue_tests.rs
+++ b/tests/fill_queue_tests.rs
@@ -72,6 +72,23 @@ async fn produce_one_is_ok() {
     build_configs_and_run_test(test).await
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn nb_free_reports_available_fill_slots() {
+    fn test(dev1: (Xsk, PacketGenerator), _dev2: (Xsk, PacketGenerator)) {
+        let mut xsk1 = dev1.0;
+
+        // `desired` is a cache-refresh threshold for producer rings, not a cap.
+        assert_eq!(xsk1.fq.nb_free(1), FQ_SIZE);
+        assert_eq!(unsafe { xsk1.fq.produce(&xsk1.descs[..2]) }, 2);
+        assert_eq!(xsk1.fq.nb_free(1), FQ_SIZE - 2);
+        assert_eq!(unsafe { xsk1.fq.produce(&xsk1.descs[2..4]) }, 2);
+        assert_eq!(xsk1.fq.nb_free(1), 0);
+    }
+
+    build_configs_and_run_test(test).await
+}
+
 async fn build_configs_and_run_test<F>(test: F)
 where
     F: Fn((Xsk, PacketGenerator), (Xsk, PacketGenerator)) + Send + 'static,

--- a/tests/rx_queue_tests.rs
+++ b/tests/rx_queue_tests.rs
@@ -390,6 +390,37 @@ async fn consume_one_headroom_len_reset_after_receive() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn nb_avail_reports_received_packets_and_honors_desired() {
+    fn test(dev1: (Xsk, PacketGenerator), dev2: (Xsk, PacketGenerator)) {
+        let mut xsk1 = dev1.0;
+        let mut xsk2 = dev2.0;
+
+        assert_eq!(xsk2.rx_q.nb_avail(RX_Q_SIZE), 0);
+
+        unsafe {
+            assert_eq!(xsk2.fq.produce(&xsk2.descs[..2]), 2);
+
+            for desc in &mut xsk1.descs[..2] {
+                xsk1.umem
+                    .data_mut(desc)
+                    .cursor()
+                    .write_all(&ETHERNET_PACKET[..])
+                    .unwrap();
+            }
+
+            assert_eq!(xsk1.tx_q.produce_and_wakeup(&xsk1.descs[..2]).unwrap(), 2);
+        }
+
+        assert!(xsk2.rx_q.poll(100).unwrap());
+        assert_eq!(xsk2.rx_q.nb_avail(1), 1);
+        assert_eq!(xsk2.rx_q.nb_avail(RX_Q_SIZE), 2);
+    }
+
+    build_configs_and_run_test(test).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn xdp_statistics_report_dropped_packet() {
     fn test(dev1: (Xsk, PacketGenerator), dev2: (Xsk, PacketGenerator)) {
         unsafe {

--- a/tests/tx_queue_tests.rs
+++ b/tests/tx_queue_tests.rs
@@ -75,6 +75,24 @@ async fn produce_one_is_ok() {
     build_configs_and_run_test(test).await
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn nb_free_reports_available_tx_slots() {
+    fn test(dev1: (Xsk, PacketGenerator), _dev2: (Xsk, PacketGenerator)) {
+        let mut xsk1 = dev1.0;
+
+        // `desired` is a cache-refresh threshold for producer rings, not a cap.
+        assert_eq!(xsk1.tx_q.nb_free(1), TX_Q_SIZE);
+        assert_eq!(unsafe { xsk1.tx_q.produce(&xsk1.descs[..2]) }, 2);
+        assert_eq!(xsk1.tx_q.nb_free(1), TX_Q_SIZE - 2);
+        assert_eq!(unsafe { xsk1.tx_q.produce(&xsk1.descs[2..4]) }, 2);
+        assert_eq!(xsk1.tx_q.nb_free(1), 0);
+    }
+
+    build_configs_and_run_test(test).await
+}
+
+
 async fn build_configs_and_run_test<F>(test: F)
 where
     F: Fn((Xsk, PacketGenerator), (Xsk, PacketGenerator)) + Send + 'static,


### PR DESCRIPTION
- Add nb_free and nb_avail APIs to XSK producer and consumer queues
- added additional test code for all four queues

required for performance optimized queue control

as it is orthogonal to feature/extended_visibility it should merge w/o issues.