### PR TITLE
Allow Config and ConfigBuilder to be created in a const context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Changed
+
+- The `Config` and `ConfigBuilder` structs can now be created and populated in a `const` context. This implies their dependent types (`QueueSize` and `FrameSize`) are also `const` compatible.
+
 ## [0.11.0] - 2026-08-28
 
 ## Fixed

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,7 @@ pub struct QueueSize(u32);
 impl QueueSize {
     /// Create a new `QueueSize` instance. Fails if `size` is not a
     /// power of two.
-    pub fn new(size: u32) -> Result<Self, QueueSizeError> {
+    pub const fn new(size: u32) -> Result<Self, QueueSizeError> {
         if !util::is_pow_of_two(size) {
             Err(QueueSizeError(size))
         } else {
@@ -39,7 +39,7 @@ impl QueueSize {
     }
 
     /// The queue size.
-    pub fn get(&self) -> u32 {
+    pub const fn get(&self) -> u32 {
         self.0
     }
 }
@@ -77,7 +77,7 @@ pub struct FrameSize(u32);
 impl FrameSize {
     /// Create a new `FrameSize` instance. Fails if `size` is smaller
     /// than [`XDP_UMEM_MIN_CHUNK_SIZE`].
-    pub fn new(size: u32) -> Result<Self, FrameSizeError> {
+    pub const fn new(size: u32) -> Result<Self, FrameSizeError> {
         if size < XDP_UMEM_MIN_CHUNK_SIZE {
             Err(FrameSizeError(size))
         } else {
@@ -86,7 +86,7 @@ impl FrameSize {
     }
 
     /// The frame size.
-    pub fn get(&self) -> u32 {
+    pub const fn get(&self) -> u32 {
         self.0
     }
 }
@@ -118,6 +118,18 @@ impl error::Error for FrameSizeError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    
+    // Testing the const creation
+    const _QUEUE_SIZE_1: QueueSize = {
+        match QueueSize::new(1) {
+            Ok(v) => v, Err(_) => panic!("out of range")
+        }
+    };
+    const _FRAME_SIZE_1: FrameSize = {
+        match FrameSize::new(XDP_UMEM_MIN_CHUNK_SIZE) {
+            Ok(v) => v, Err(_) => panic!("out of range")
+        }
+    };
 
     #[test]
     fn queue_size_should_accept_only_non_zero_powers_of_two() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -118,16 +118,18 @@ impl error::Error for FrameSizeError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     // Testing the const creation
     const _QUEUE_SIZE_1: QueueSize = {
         match QueueSize::new(1) {
-            Ok(v) => v, Err(_) => panic!("out of range")
+            Ok(v) => v,
+            Err(_) => panic!("out of range"),
         }
     };
     const _FRAME_SIZE_1: FrameSize = {
         match FrameSize::new(XDP_UMEM_MIN_CHUNK_SIZE) {
-            Ok(v) => v, Err(_) => panic!("out of range")
+            Ok(v) => v,
+            Err(_) => panic!("out of range"),
         }
     };
 

--- a/src/config/umem.rs
+++ b/src/config/umem.rs
@@ -15,7 +15,6 @@ pub struct ConfigBuilder {
 }
 
 impl ConfigBuilder {
-
     /// Creates a new [`UmemConfigBuilder`](ConfigBuilder) instance.
     pub const fn new() -> Self {
         ConfigBuilder {
@@ -107,23 +106,23 @@ pub struct Config {
 }
 
 impl Config {
-
     const fn new_default() -> Config {
-
         const DEFAULT_FRAME_SIZE: FrameSize = match FrameSize::new(XSK_UMEM__DEFAULT_FRAME_SIZE) {
             Ok(frame_size) => frame_size,
             Err(_) => panic!("Invalid default frame size"),
         };
 
-        const DEFAULT_FILL_QUEUE_SIZE: QueueSize = match QueueSize::new(XSK_RING_PROD__DEFAULT_NUM_DESCS) {
-            Ok(fill_queue_size) => fill_queue_size,
-            Err(_) => panic!("Invalid default fill queue size"),
-        };
+        const DEFAULT_FILL_QUEUE_SIZE: QueueSize =
+            match QueueSize::new(XSK_RING_PROD__DEFAULT_NUM_DESCS) {
+                Ok(fill_queue_size) => fill_queue_size,
+                Err(_) => panic!("Invalid default fill queue size"),
+            };
 
-        const DEFAULT_COMP_QUEUE_SIZE: QueueSize = match QueueSize::new(XSK_RING_CONS__DEFAULT_NUM_DESCS) {
-            Ok(comp_queue_size) => comp_queue_size,
-            Err(_) => panic!("Invalid default completion queue size"),
-        };
+        const DEFAULT_COMP_QUEUE_SIZE: QueueSize =
+            match QueueSize::new(XSK_RING_CONS__DEFAULT_NUM_DESCS) {
+                Ok(comp_queue_size) => comp_queue_size,
+                Err(_) => panic!("Invalid default completion queue size"),
+            };
 
         Config {
             frame_size: DEFAULT_FRAME_SIZE,

--- a/src/config/umem.rs
+++ b/src/config/umem.rs
@@ -15,28 +15,31 @@ pub struct ConfigBuilder {
 }
 
 impl ConfigBuilder {
+
     /// Creates a new [`UmemConfigBuilder`](ConfigBuilder) instance.
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        ConfigBuilder {
+            config: Config::new_default(),
+        }
     }
 
     /// Set the frame size. Default is
     /// [`XSK_UMEM__DEFAULT_FRAME_SIZE`]. Must be a power of two.
-    pub fn frame_size(&mut self, size: FrameSize) -> &mut Self {
+    pub const fn frame_size(&mut self, size: FrameSize) -> &mut Self {
         self.config.frame_size = size;
         self
     }
 
     /// Set the [`FillQueue`](crate::FillQueue) size. Default is
     /// [`XSK_RING_PROD__DEFAULT_NUM_DESCS`].
-    pub fn fill_queue_size(&mut self, size: QueueSize) -> &mut Self {
+    pub const fn fill_queue_size(&mut self, size: QueueSize) -> &mut Self {
         self.config.fill_queue_size = size;
         self
     }
 
     /// Set the [`CompQueue`](crate::CompQueue) size. Default is
     /// [`XSK_RING_CONS__DEFAULT_NUM_DESCS`].
-    pub fn comp_queue_size(&mut self, size: QueueSize) -> &mut Self {
+    pub const fn comp_queue_size(&mut self, size: QueueSize) -> &mut Self {
         self.config.comp_queue_size = size;
         self
     }
@@ -47,7 +50,7 @@ impl ConfigBuilder {
     /// Not to be confused with [`XDP_PACKET_HEADROOM`] which is the
     /// amount of headroom reserved by XDP. This headroom sits at the
     /// start of the frame, ahead of the XDP program's.
-    pub fn frame_headroom(&mut self, headroom: u32) -> &mut Self {
+    pub const fn frame_headroom(&mut self, headroom: u32) -> &mut Self {
         self.config.frame_headroom = headroom;
         self
     }
@@ -58,7 +61,7 @@ impl ConfigBuilder {
     /// May fail if some of the values are incompatible. For example,
     /// if the requested frame headroom leaves no room in the frame for
     /// packet data, or if the frame size is not a power of two.
-    pub fn build(&self) -> Result<Config, ConfigBuildError> {
+    pub const fn build(&self) -> Result<Config, ConfigBuildError> {
         let frame_size = self.config.frame_size.get();
 
         if !util::is_pow_of_two(frame_size) {
@@ -104,35 +107,61 @@ pub struct Config {
 }
 
 impl Config {
+
+    const fn new_default() -> Config {
+
+        const DEFAULT_FRAME_SIZE: FrameSize = match FrameSize::new(XSK_UMEM__DEFAULT_FRAME_SIZE) {
+            Ok(frame_size) => frame_size,
+            Err(_) => panic!("Invalid default frame size"),
+        };
+
+        const DEFAULT_FILL_QUEUE_SIZE: QueueSize = match QueueSize::new(XSK_RING_PROD__DEFAULT_NUM_DESCS) {
+            Ok(fill_queue_size) => fill_queue_size,
+            Err(_) => panic!("Invalid default fill queue size"),
+        };
+
+        const DEFAULT_COMP_QUEUE_SIZE: QueueSize = match QueueSize::new(XSK_RING_CONS__DEFAULT_NUM_DESCS) {
+            Ok(comp_queue_size) => comp_queue_size,
+            Err(_) => panic!("Invalid default completion queue size"),
+        };
+
+        Config {
+            frame_size: DEFAULT_FRAME_SIZE,
+            fill_queue_size: DEFAULT_FILL_QUEUE_SIZE,
+            comp_queue_size: DEFAULT_COMP_QUEUE_SIZE,
+            frame_headroom: XSK_UMEM__DEFAULT_FRAME_HEADROOM,
+        }
+    }
+
     /// Creates a new [`UmemConfigBuilder`](ConfigBuilder) instance
     /// with with sizes as per the `libbpf` defaults.
-    pub fn builder() -> ConfigBuilder {
+    pub const fn builder() -> ConfigBuilder {
         ConfigBuilder::new()
     }
 
     /// The size of each frame in the [`Umem`](crate::Umem).
-    pub fn frame_size(&self) -> FrameSize {
+    pub const fn frame_size(&self) -> FrameSize {
         self.frame_size
     }
 
     /// The [`FillQueue`](crate::FillQueue) size.
-    pub fn fill_queue_size(&self) -> QueueSize {
+    pub const fn fill_queue_size(&self) -> QueueSize {
         self.fill_queue_size
     }
 
     /// The [`CompQueue`](crate::CompQueue) size.
-    pub fn comp_queue_size(&self) -> QueueSize {
+    pub const fn comp_queue_size(&self) -> QueueSize {
         self.comp_queue_size
     }
 
     /// The frame headroom reserved for the XDP program.
-    pub fn xdp_headroom(&self) -> u32 {
+    pub const fn xdp_headroom(&self) -> u32 {
         XDP_PACKET_HEADROOM
     }
 
     /// The frame headroom available to the user, at the start of the
     /// frame.
-    pub fn frame_headroom(&self) -> u32 {
+    pub const fn frame_headroom(&self) -> u32 {
         self.frame_headroom
     }
 
@@ -141,19 +170,14 @@ impl Config {
     ///
     /// Is defined as the frame size minus both the XDP headroom and
     /// user headroom.
-    pub fn mtu(&self) -> u32 {
+    pub const fn mtu(&self) -> u32 {
         self.frame_size.get() - (self.xdp_headroom() + self.frame_headroom)
     }
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self {
-            frame_size: FrameSize(XSK_UMEM__DEFAULT_FRAME_SIZE),
-            fill_queue_size: QueueSize(XSK_RING_PROD__DEFAULT_NUM_DESCS),
-            comp_queue_size: QueueSize(XSK_RING_CONS__DEFAULT_NUM_DESCS),
-            frame_headroom: XSK_UMEM__DEFAULT_FRAME_HEADROOM,
-        }
+        Config::new_default()
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ pub fn get_errno() -> i32 {
 }
 
 #[inline]
-pub fn is_pow_of_two(val: u32) -> bool {
+pub const fn is_pow_of_two(val: u32) -> bool {
     if val == 0 {
         return false;
     }


### PR DESCRIPTION
Allow `Config` and `ConfigBuilder` to be created in a `const` context to allow compile time checking of a fixed constant configuration.